### PR TITLE
Run the command immediately at startup instead of waiting first

### DIFF
--- a/main.go
+++ b/main.go
@@ -69,6 +69,10 @@ func main() {
 	args := flag.Args()[1:]
 
 	go func() {
+		// Run once immediately at startup
+		run(command, args)
+
+		// Then start the delay loop
 		for range time.Tick(*period) {
 			run(command, args)
 		}


### PR DESCRIPTION
If the delay period is longer than a minute or two, it can be troublesome if prom-run doesn't execute the requested command until after the first period expires.