### PR TITLE
Print output even on success

### DIFF
--- a/main.go
+++ b/main.go
@@ -136,7 +136,8 @@ func run(command string, args []string) {
 	outputLock.Unlock()
 
 	if err == nil {
-		log.Printf("Command exited successfully")
+		log.Println("Command exited successfully")
+		log.Println("Output: ", string(out))
 		statusCode.WithLabelValues("0").Inc()
 		lastSuccessTimestamp.SetToCurrentTime()
 	} else {


### PR DESCRIPTION
The output of a cronjob is often useful to track over time as well.

Signed-off-by: Annanay Agarwal <annanay.agarwal@grafana.com>